### PR TITLE
Fix compilation with Qt-5.2.1

### DIFF
--- a/src/qml/qml.qbs
+++ b/src/qml/qml.qbs
@@ -32,6 +32,7 @@ Product {
     Depends { name: "Qt.network" }        
     Depends { name: "Qt.declarative"; condition: Qt.core.versionMajor === 4 }
     Depends { name: "Qt.quick"; condition: Qt.core.versionMajor === 5 }
+    Depends { name: "Qt.widgets"; condition: Qt.core.versionMajor === 5 }
     Depends { name: "vreen"}
     Depends { name: "vreenoauth" }
     Depends { name: "vreen.core" }


### PR DESCRIPTION
QApplication is part of Qt.widgets.

Without that compilation fails with many `"QApplication" not found` errors.
