### PR TITLE
Build fixes

### DIFF
--- a/modules/vreen/core/core.qbs
+++ b/modules/vreen/core/core.qbs
@@ -11,6 +11,7 @@ Module {
     property string versionMajor:  1
     property string versionMinor: 8
     property string versionRelease: 0
+    property string version: versionMajor + '.' + versionMinor + '.' + versionRelease
 
     Depends { name: "cpp" }
     Depends { name: "Qt.core"}

--- a/src/api.qbs
+++ b/src/api.qbs
@@ -28,6 +28,8 @@ Product {
         "api/*.cpp",
     ]
 
+    qbsSearchPaths: "../"
+
     Depends { name: "cpp" }
     Depends { name: "Qt"; submodules: ["core", "network", "gui"] }
     Depends { name: "k8json" }
@@ -41,7 +43,7 @@ Product {
         cpp.includePaths: [
             product.buildDirectory + "/GeneratedFiles/include",
             product.buildDirectory + "/GeneratedFiles/include/vreen",
-            product.buildDirectory + "/GeneratedFiles/include/vreen/" +  vreen.core.version
+            product.buildDirectory + "/GeneratedFiles/include/vreen/" + vreen.core.version
         ]
         cpp.rpaths: product.buildDirectory + "/" + vreen.core.libDestination
     }


### PR DESCRIPTION
Vreen.core (and vreen.core.version) is used in api.qbs, but QBS fails to find that module without qbsSearchPaths.
In QBS 1.3.3 it silently gives me an "undefined" value.

I also would like to know something about this line
https://github.com/euroelessar/qutim/blob/master/src/plugins/protocols/protocols.qbs#L10
And this:
https://github.com/gorthauer/vreen/blob/master/vreen.qbs#L5
(qutim_qml_path is equal to "bin" in qutIM, so nothing changed)

Do you **really** want to install Vreen/Base/PhotoModel.qml, Vreen/Base/libvreenplugin.so and Vreen/Base/qmldir to /usr/bin? I suggest (in qutIM), that you want to install it to share/apps/qutim/ .
